### PR TITLE
Support for CoreUpdate options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ cluster.createCluster({
   discoveryServiceUrl: 'https://discovery.etcd.io/some-guid-here',
   privateNetwork: '4c371711-44ae-15ab-86af-45438fb96a15',
   monitoringToken: 'your-monitoring-token',
-  updateGroup: '0a809ab1-c01c-4a6b-8ac8-6b17cb9bae09',
-  updateServer: 'https://customer.update.core-os.net/v1/update/'
+  update: {
+      group: '0a809ab1-c01c-4a6b-8ac8-6b17cb9bae09',
+      server: 'https://customer.update.core-os.net/v1/update/'
+  },
   credentials: {
     username: 'your-user-name',
     apiKey: 'some-key-here',

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ cluster.createCluster({
   discoveryServiceUrl: 'https://discovery.etcd.io/some-guid-here',
   privateNetwork: '4c371711-44ae-15ab-86af-45438fb96a15',
   monitoringToken: 'your-monitoring-token',
+  updateGroup: '0a809ab1-c01c-4a6b-8ac8-6b17cb9bae09',
+  updateServer: 'https://customer.update.core-os.net/v1/update/'
   credentials: {
     username: 'your-user-name',
     apiKey: 'some-key-here',

--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ var Cluster = require('./lib/cluster').Cluster;
  * @param {string}      [options.keyname]     ssh keyname; if not provided will create a new key 'coreos-cluster'
  * @param {string}      [options.privateNetwork]     optional private network guid to use for rackspace private network
  * @param {string}      [options.monitoringToken]    optional monitoring token to configure cloud monitoring
+ * @param {string}      [options.updateGroup]     optional update group (e.g. stable, beta, UUID for a channel)
+ * @param {string}      [options.updateServer]     optional omaha endpoint URL for updates
  * @param {string}      [options.discoverServiceUrl] url for an existing cluster's discover service
  * @param {string}      [options.keyname]     ssh keyname; if not provided will create a new key 'coreos-cluster'
  *

--- a/index.js
+++ b/index.js
@@ -11,10 +11,11 @@ var Cluster = require('./lib/cluster').Cluster;
  * @param {string}      [options.keyname]     ssh keyname; if not provided will create a new key 'coreos-cluster'
  * @param {string}      [options.privateNetwork]     optional private network guid to use for rackspace private network
  * @param {string}      [options.monitoringToken]    optional monitoring token to configure cloud monitoring
- * @param {string}      [options.updateGroup]     optional update group (e.g. stable, beta, UUID for a channel)
- * @param {string}      [options.updateServer]     optional omaha endpoint URL for updates
  * @param {string}      [options.discoverServiceUrl] url for an existing cluster's discover service
- * @param {string}      [options.keyname]     ssh keyname; if not provided will create a new key 'coreos-cluster'
+ * @param {string}      [options.keyname]            ssh keyname; if not provided will create a new key 'coreos-cluster'
+ * @param {object}      [options.update]             options for CoreOS updates
+ * @param {string}      [options.update.group]       optional update group (e.g. stable, beta, UUID for a channel)
+ * @param {string}      [options.update.server]      optional omaha endpoint URL for updates
  *
  * @param callback      callback with err, results
  */

--- a/lib/cloud-config.js
+++ b/lib/cloud-config.js
@@ -63,15 +63,19 @@ exports.getCloudConfig = function(options, callback) {
     template.coreos.etcd.discovery = options.discoveryServiceUrl;
     template.coreos.fleet.metadata = 'provider=rackspace,region=' + options.region;
     
-    // The update group. Can be "master", "stable", "alpha", or a
-    // UUID for a custom group
-    if(options.update.group) {
-        template.coreos.update.group = options.update.group;
-    }
-    
-    // The omaha endpoint URL which will be queried for updates.
-    if(options.update.server) {
-        template.coreos.update.server = options.update.server;
+    // CoreOS update settings
+    if (options.update) {
+      // The update group. Can be "master", "stable", "alpha", or a
+      // UUID for a custom group
+      if (options.update.group) {
+          template.coreos.update.group = options.update.group;
+      }
+      
+      // The omaha endpoint URL which will be queried for updates.
+      if (options.update.server) {
+          template.coreos.update.server = options.update.server;
+      }
+
     }
 
     if (options.monitoringToken) {

--- a/lib/cloud-config.js
+++ b/lib/cloud-config.js
@@ -62,6 +62,17 @@ exports.getCloudConfig = function(options, callback) {
 
     template.coreos.etcd.discovery = options.discoveryServiceUrl;
     template.coreos.fleet.metadata = 'provider=rackspace,region=' + options.region;
+    
+    // The update channel. Can be "master", "stable", "alpha", or a
+    // release channel of your own configuration
+    if(options.updateGroup) {
+        template.coreos.update.group = options.updateGroup;
+    }
+    
+    // The omaha endpoint URL which will be queried for updates.
+    if(options.updateServer) {
+        template.coreos.update.server = options.updateServer;
+    }
 
     if (options.monitoringToken) {
       template.coreos.units = template.coreos.units.concat(_.cloneDeep(monitoringTemplate));

--- a/lib/cloud-config.js
+++ b/lib/cloud-config.js
@@ -63,15 +63,15 @@ exports.getCloudConfig = function(options, callback) {
     template.coreos.etcd.discovery = options.discoveryServiceUrl;
     template.coreos.fleet.metadata = 'provider=rackspace,region=' + options.region;
     
-    // The update channel. Can be "master", "stable", "alpha", or a
-    // release channel of your own configuration
-    if(options.updateGroup) {
-        template.coreos.update.group = options.updateGroup;
+    // The update group. Can be "master", "stable", "alpha", or a
+    // UUID for a custom group
+    if(options.update.group) {
+        template.coreos.update.group = options.update.group;
     }
     
     // The omaha endpoint URL which will be queried for updates.
-    if(options.updateServer) {
-        template.coreos.update.server = options.updateServer;
+    if(options.update.server) {
+        template.coreos.update.server = options.update.server;
     }
 
     if (options.monitoringToken) {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -18,7 +18,7 @@ var Cluster = function(options) {
   this.monitoringToken = options.monitoringToken;
   this.newDiscoveryServiceUrl = options.newDiscoveryServiceUrl || 'https://discovery.etcd.io/new';
   this.privateNetwork = options.privateNetwork;
-  this.update = options.update;
+  this.update = options.update || {};
 
 
   if (this.privateNetwork && this.type === 'onMetal') {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -18,6 +18,7 @@ var Cluster = function(options) {
   this.monitoringToken = options.monitoringToken;
   this.newDiscoveryServiceUrl = options.newDiscoveryServiceUrl || 'https://discovery.etcd.io/new';
   this.privateNetwork = options.privateNetwork;
+  this.update = options.update;
 
 
   if (this.privateNetwork && this.type === 'onMetal') {
@@ -155,8 +156,7 @@ Cluster.prototype.initialize = function(callback) {
     cloudConfig.getCloudConfig({
       privateNetwork: self.privateNetwork,
       monitoringToken: self.monitoringToken,
-      updateGroup: self.updateGroup,
-      updateServer: self.updateServer,
+      update: self.update,
       discoveryServiceUrl: self.discoveryServiceUrl,
       region: self._credentials.region
     }, function(err, config) {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -155,6 +155,8 @@ Cluster.prototype.initialize = function(callback) {
     cloudConfig.getCloudConfig({
       privateNetwork: self.privateNetwork,
       monitoringToken: self.monitoringToken,
+      updateGroup: self.updateGroup,
+      updateServer: self.updateServer,
       discoveryServiceUrl: self.discoveryServiceUrl,
       region: self._credentials.region
     }, function(err, config) {


### PR DESCRIPTION
This provides the [options for CoreUpdate](https://coreos.com/docs/coreupdate/coreos/coreupdate-configure-machines/).

Follow on PR to coreos-cluster-cli will come after this is merged and released.
