### PR TITLE
[WIP] Bring in onmetal-fast-docker for OnMetalIO

### DIFF
--- a/lib/template/rackspace-onmetal-io/etc/sysctl.d/nmi_watchdog.conf
+++ b/lib/template/rackspace-onmetal-io/etc/sysctl.d/nmi_watchdog.conf
@@ -1,0 +1,1 @@
+kernel.nmi_watchdog=0

--- a/lib/template/rackspace-onmetal-io/lsi-docker-mount.service
+++ b/lib/template/rackspace-onmetal-io/lsi-docker-mount.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Add mounts for lsi cards into /var/lib/docker
+Before=docker.service
+After=lsi-initial-setup.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/root/bin/add_raid_uuid_to_fstab.sh

--- a/lib/template/rackspace-onmetal-io/lsi-initial-setup.service
+++ b/lib/template/rackspace-onmetal-io/lsi-initial-setup.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Format and raid LSI cards if not already done
+After=lsi-settings.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/root/bin/lsi_format.sh %m

--- a/lib/template/rackspace-onmetal-io/lsi-settings.service
+++ b/lib/template/rackspace-onmetal-io/lsi-settings.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Configure performance settings for LSI cards
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/root/bin/lsi_settings.sh

--- a/lib/template/rackspace-onmetal-io/root/bin/add_raid_uuid_to_fstab.sh
+++ b/lib/template/rackspace-onmetal-io/root/bin/add_raid_uuid_to_fstab.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+UUID=`lsblk -o NAME,TYPE,UUID | grep raid0 | awk '{print $3}' | head -n1`
+grep -q $UUID /etc/fstab && echo "Device already in fstab" && exit 0
+echo "UUID=$UUID /var/lib/docker btrfs defaults 0 1" >> /etc/fstab
+mkdir -p /var/lib/docker
+mount /var/lib/docker
+chown root:root /var/lib/docker
+chmod 700 /var/lib/docker

--- a/lib/template/rackspace-onmetal-io/root/bin/lsi_device_paths.sh
+++ b/lib/template/rackspace-onmetal-io/root/bin/lsi_device_paths.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+for blockdev in `/root/bin/lsi_device_paths.sh`; do
+    echo "Applying SSD settings to ${blockdev}"
+    echo noop | tee /sys/block/${blockdev}/queue/scheduler
+    echo 4096 | tee /sys/block/${blockdev}/queue/nr_requests
+    echo 1024 | tee /sys/block/${blockdev}/queue/max_sectors_kb
+    echo 1 | tee /sys/block/${blockdev}/queue/nomerges
+    echo 512 | tee /sys/block/${blockdev}/device/queue_depth
+done

--- a/lib/template/rackspace-onmetal-io/root/bin/lsi_format.sh
+++ b/lib/template/rackspace-onmetal-io/root/bin/lsi_format.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+fail() {
+  echo $@
+  exit 1
+}
+
+# Machine ID is "free" from systemd. This also is bonus protection
+# against someone running this outside of systemd and breaking their machine.
+MACHINE_ID=${1}
+[ -z "$MACHINE_ID" ] && fail "error; machine ID should be passed in"
+
+GFILE="/etc/${MACHINE_ID}.raid-setup"
+[ -e "${GFILE}" ] && echo "${GFILE} exists, raid already setup?" && exit 0
+
+[ -b "/dev/md0" ] && mdadm --stop /dev/md0
+
+BLOCKS=""
+for blockdev in `/root/bin/lsi_device_paths.sh`; do
+  BLOCKS="${BLOCKS} /dev/${blockdev}"
+done
+
+yes | mdadm --create --verbose -f /dev/md0 --level=stripe --raid-devices=2 ${BLOCKS}
+mkfs.btrfs /dev/md0
+touch /etc/${MACHINE_ID}.raid-setup


### PR DESCRIPTION
This brings in some of the pieces from https://github.com/jayofdoom/onmetal-fast-docker, to setup the LSI Nytro WarpDrives and put `/var/lib/docker` in them. I committed as @jayofdoom to give him credit for the initial files. I'll be adding in configuration sometime later.

We probably want to make this generic enough that if you want it to only setup the cards (but not mount docker there), you can do that.

One piece that will need to be added to the produced config is:

```
coreos:
  units:
    - name: systemd-sysctl.service
      command: restart
```
