### PR TITLE
Basename

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var Cluster = require('./lib/cluster').Cluster;
  * Create a coreos cluster
  *
  * @param {object}      options               options for your new cluster
+ * @param {string}      [options.basename]    basename for the cluster, "cluster-" is default (e.g. cluster-1413933515-03)
  * @param {string}      [options.type]        'onMetal' or 'performance', performance is default
  * @param {string}      [options.flavor]      cloud servers flavor, defaults to smallest for type
  * @param {string}      [options.release]     coreos release, 'alpha', 'beta', 'stable', stable is default

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -8,6 +8,7 @@ var async = require('async'),
 var Cluster = function(options) {
   options = options || {};
 
+  this.basename = options.basename || 'cluster-';
   this.type = helpers.getType(options.type);
   this.release = helpers.getRelease(options.release);
   this.flavor = helpers.getFlavor(options.flavor, this.type);
@@ -228,7 +229,7 @@ Cluster.prototype.addNodes = function(number, callback) {
   }
 
   for (var i = 1; i <= number; i++) {
-    names.push('cluster-' +
+    names.push(self.basename +
       Math.floor((Date.now() / 1000)) + '-' +
       helpers.pad(i, 2));
   }


### PR DESCRIPTION
Allows user to set the basename for the cluster.

I've been using it for a bit and it would be way easier for me to regard specific clusters with a name beyond the date.

Closes #6 
