### PR TITLE
Don't rewrite rackspace-ips.sh

### DIFF
--- a/lib/cloud-config.js
+++ b/lib/cloud-config.js
@@ -97,7 +97,9 @@ exports.getCloudConfig = function(options, callback) {
     if (options.privateNetwork) {
       _.each(template.write_files, function(file) {
         if (path.basename(file.path)) {
-          file.content = file.content.replace(/RAX_SERVICENET_IPV4/gi, 'RAX_PRIVATENET_IPV4');
+          if (file.path !== '/root/bin/rackspace-ips.sh') {
+            file.content = file.content.replace(/RAX_SERVICENET_IPV4/gi, 'RAX_PRIVATENET_IPV4');
+          }
         }
       });
     }


### PR DESCRIPTION
Hey @kenperkins,

When testing the --private-network flag of the cli, we found that /etc/environment was being populated incorrectly.  RAX_PRIVATENET_IPV4 was being listed twice, with two ips (private & service).

This patch skips the incorrect regex rewrite of rackspace-ips.sh script
