### PR TITLE
Add ephemeral option for using data disk for Docker storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var Cluster = require('./lib/cluster').Cluster;
  * @param {string}      [options.keyname]     ssh keyname; if not provided will create a new key 'coreos-cluster'
  * @param {string}      [options.privateNetwork]     optional private network guid to use for rackspace private network
  * @param {string}      [options.monitoringToken]    optional monitoring token to configure cloud monitoring
+ * @param {string}      [options.ephemeral]    optional utilize data disk (ephemeral) for Docker storage
  * @param {string}      [options.discoverServiceUrl] url for an existing cluster's discover service
  * @param {string}      [options.keyname]            ssh keyname; if not provided will create a new key 'coreos-cluster'
  * @param {object}      [options.update]             options for CoreOS updates

--- a/lib/cloud-config.js
+++ b/lib/cloud-config.js
@@ -3,11 +3,15 @@ var async = require('async'),
     fs = require('fs'),
     path = require('path'),
     monitoringTemplate = require('./template/rackspace-monitoring-units.json'),
+    ephemeralTemplate = require('./template/ephemeral-units.json'),
     yaml = require('js-yaml'),
     _ = require('lodash');
 
 var filePaths = [
   'fixup-etc.sh',
+  'format-ephemeral.service',
+  'format-ephemeral.sh',
+  'var-lib-docker.mount',
   'rackspace-ips.sh',
   'rackspace-monitoring-agent.service',
   'rackspace-monitoring-agent-id.service',
@@ -80,6 +84,10 @@ exports.getCloudConfig = function(options, callback) {
 
     if (options.monitoringToken) {
       template.coreos.units = template.coreos.units.concat(_.cloneDeep(monitoringTemplate));
+    }
+
+    if (options.ephemeral) {
+      template.coreos.units = template.coreos.units.concat(_.cloneDeep(ephemeralTemplate));
     }
 
     _.each(template.coreos.units, function(unit) {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -17,6 +17,7 @@ var Cluster = function(options) {
   this.discoveryServiceUrl = options.discoveryServiceUrl;
   this.keyname = options.keyname;
   this.monitoringToken = options.monitoringToken;
+  this.ephemeral = options.ephemeral;
   this.newDiscoveryServiceUrl = options.newDiscoveryServiceUrl || 'https://discovery.etcd.io/new';
   this.privateNetwork = options.privateNetwork;
   this.update = options.update || {};
@@ -157,6 +158,7 @@ Cluster.prototype.initialize = function(callback) {
     cloudConfig.getCloudConfig({
       privateNetwork: self.privateNetwork,
       monitoringToken: self.monitoringToken,
+      ephemeral: self.ephemeral,
       update: self.update,
       discoveryServiceUrl: self.discoveryServiceUrl,
       region: self._credentials.region

--- a/lib/template/basic-config.json
+++ b/lib/template/basic-config.json
@@ -36,6 +36,11 @@
       "path": "/root/bin/rackspace-ips.sh",
       "permissions": "0755",
       "content": null
+    },
+    {
+      "path": "/root/bin/format-ephemeral.sh",
+      "permissions": "0755",
+      "content": null
     }
   ]
 }

--- a/lib/template/ephemeral-units.json
+++ b/lib/template/ephemeral-units.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "format-ephemeral.service",
+    "command": "start",
+    "runtime": "yes",
+    "content": null
+  },
+  {
+    "name": "var-lib-docker.mount",
+    "command": "start",
+    "runtime": "yes",
+    "content": null
+  }
+]

--- a/lib/template/format-ephemeral.service
+++ b/lib/template/format-ephemeral.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Formats the ephemeral drive
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/root/bin/format-ephemeral.sh

--- a/lib/template/format-ephemeral.sh
+++ b/lib/template/format-ephemeral.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+echo "Running format-ephemeral.sh"
+blkid /dev/xvde | grep btrfs >> /dev/null
+if [ $? -eq 0 ]; then
+  echo "/dev/xvde already formatted as btrfs"
+  exit 0
+fi
+
+echo "Wiping /dev/xvde"
+wipefs -f /dev/xvde
+echo "Formatting /dev/xvde as btrfs"
+mkfs.btrfs -f /dev/xvde

--- a/lib/template/var-lib-docker.mount
+++ b/lib/template/var-lib-docker.mount
@@ -1,0 +1,9 @@
+[Unit]
+Description=Mount ephemeral to /var/lib/docker
+After=format-ephemeral.service
+Before=docker.service
+
+[Mount]
+What=/dev/xvde
+Where=/var/lib/docker
+Type=btrfs

--- a/test/base-test.js
+++ b/test/base-test.js
@@ -37,6 +37,14 @@ describe('Tests for creating a core-os cluster', function() {
       cluster.type.should.equal('onMetal');
     });
   });
+  
+  describe('cluster.ephemeral', function() {
+    it('should allow setting Docker disk drive', function() {
+      var cluster = new Cluster({ephemeral: true})
+      
+      cluster.ephemeral.should.equal(true);
+    })
+  })
 
   describe('cluster.release', function() {
     it('should not allow a custom cluster release', function() {


### PR DESCRIPTION
This pull request adds a new option 'ephemeral' which uses the ephemeral data-disk for Docker storage.  Specifically, we wipe, format, and mount /dev/xvde which is the data-disk in Rackspace to /var/lib/docker.
